### PR TITLE
Remove 'fs' and 'http' dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
   "homepage": "https://github.com/tagyoureit/nodejs-Pentair#readme",
   "dependencies": {
     "express": "^4.14.0",
-    "fs": "0.0.2",
-    "http": "0.0.0",
     "serialport": "^3.1.2",
     "socket.io": "^1.4.8",
     "winston": "^2.2.0"


### PR DESCRIPTION
Ref: http://npm.im/fs

Not sure you need `http` dependency either: https://www.npmjs.com/package/http
You're probably using the built-in `http` Node.js dependency: https://nodejs.org/api/http.html
